### PR TITLE
Add unit tests for algorand/go-algorand#2172

### DIFF
--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -112,7 +112,7 @@ func (sd StateDelta) Valid(proto *config.ConsensusParams) error {
 				return fmt.Errorf("value too long for key 0x%x: length was %d", key, len(delta.Bytes))
 			}
 			if sum := len(key) + len(delta.Bytes); sum > proto.MaxAppSumKeyValueLens {
-				return fmt.Errorf("key/value too long for key 0x%x: sum was %d", key, sum)
+				return fmt.Errorf("key/value total too long for key 0x%x: sum was %d", key, sum)
 			}
 		case SetUintAction:
 		case DeleteAction:

--- a/data/basics/teal_test.go
+++ b/data/basics/teal_test.go
@@ -47,25 +47,27 @@ func TestStateDeltaValid(t *testing.T) {
 	a.Error(err)
 	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
 
-	// test proto with applications
+	// test vFuture proto with applications
 	sd = StateDelta{"key": ValueDelta{Action: SetBytesAction, Bytes: "val"}}
 	protoF := config.Consensus[protocol.ConsensusFuture]
 	err = sd.Valid(&protoF)
 	a.NoError(err)
 
+	// vFuture: key too long, short value
 	tooLongKey := strings.Repeat("a", protoF.MaxAppKeyLen+1)
-	sd[tooLongKey] = ValueDelta{Action: SetBytesAction, Bytes: "val"}
+	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
 	err = sd.Valid(&protoF)
 	a.Error(err)
 	a.Contains(err.Error(), "key too long")
 	delete(sd, tooLongKey)
 
+	// vFuture: max size key, value too long: total size bigger than MaxAppSumKeyValueLens
 	longKey := tooLongKey[1:]
 	tooLongValue := strings.Repeat("b", protoF.MaxAppSumKeyValueLens-len(longKey)+1)
-	sd[longKey] = ValueDelta{Action: SetBytesAction, Bytes: tooLongValue}
+	sd = StateDelta{longKey: ValueDelta{Action: SetBytesAction, Bytes: tooLongValue}}
 	err = sd.Valid(&protoF)
 	a.Error(err)
-	a.Contains(err.Error(), "value too long for key")
+	a.Contains(err.Error(), "key/value total too long for key")
 
 	sd[longKey] = ValueDelta{Action: SetBytesAction, Bytes: tooLongValue[1:]}
 	sd["intval"] = ValueDelta{Action: DeltaAction(10), Uint: 0}
@@ -77,6 +79,27 @@ func TestStateDeltaValid(t *testing.T) {
 	sd["delval"] = ValueDelta{Action: DeleteAction, Uint: 0, Bytes: tooLongValue}
 	err = sd.Valid(&protoF)
 	a.NoError(err)
+}
+
+func TestStateDeltaValidV24(t *testing.T) {
+	a := require.New(t)
+
+	// v24: short key, value too long: hits MaxAppBytesValueLen
+	protoV24 := config.Consensus[protocol.ConsensusV24]
+	shortKey := "k"
+	reallyLongValue := strings.Repeat("b", protoV24.MaxAppBytesValueLen+1)
+	sd := StateDelta{shortKey: ValueDelta{Action: SetBytesAction, Bytes: reallyLongValue}}
+	err := sd.Valid(&protoV24)
+	a.Error(err)
+	a.Contains(err.Error(), "value too long for key")
+
+	// v24: key too long, short value
+	tooLongKey := strings.Repeat("a", protoV24.MaxAppKeyLen+1)
+	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
+	err = sd.Valid(&protoV24)
+	a.Error(err)
+	a.Contains(err.Error(), "key too long")
+	delete(sd, tooLongKey)
 }
 
 func TestStateDeltaEqual(t *testing.T) {

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -336,7 +336,7 @@ func (cb *roundCowState) SetKey(addr basics.Address, aidx basics.AppIndex, globa
 			return fmt.Errorf("value too long for key 0x%x: length was %d", key, len(value.Bytes))
 		}
 		if sum := len(key) + len(value.Bytes); sum > cb.proto.MaxAppSumKeyValueLens {
-			return fmt.Errorf("key/value too long for key 0x%x: sum was %d", key, sum)
+			return fmt.Errorf("key/value total too long for key 0x%x: sum was %d", key, sum)
 		}
 	}
 


### PR DESCRIPTION
While writing these I ran coverage reports and discovered that some of the error checks in `TestStateDeltaValid` didn't seem to be deterministically creating the same error every time, because extra `ValueDelta` changes were being added to the same `StateDelta` for the `tooLongKey` and `longKey` cases. So I disambiguated the error string ("key/value total too long") to be able to precisely target the error being checked and cleared `StateDelta` for each of those cases.

Tested with:
`go test -v -run TestStateDeltaValid --tags "sqlite_unlock_notify sqlite_omit_load_extension " -coverprofile=cover.out github.com/algorand/go-algorand/data/basics && go tool cover -html=cover.out`

`go test -v -run TestCowSetKey --tags "sqlite_unlock_notify sqlite_omit_load_extension " -coverprofile=cover.out github.com/algorand/go-algorand/ledger && go tool cover -html=cover.out`