### PR TITLE
Feature/contract to contract (#3395)

### DIFF
--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -778,17 +778,6 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 Decodes A using the base64 encoding E. Specify the encoding with an immediate arg either as URL and Filename Safe (`URLEncoding`) or Standard (`StdEncoding`). See <a href="https://rfc-editor.org/rfc/rfc4648.html#section-4">RFC 4648</a> (sections 4 and 5). It is assumed that the encoding ends with the exact number of `=` padding characters as required by the RFC. When padding occurs, any unused pad bits in the encoding must be set to zero or the decoding will fail. The special cases of `\n` and `\r` are allowed but completely ignored. An error will result when attempting to decode a string with a character that is not in the encoding alphabet or not one of `=`, `\r`, or `\n`.
 
-## base64_decode e
-
-- Opcode: 0x5c {uint8 encoding index}
-- Pops: *... stack*, []byte
-- Pushes: []byte
-- decode X which was base64-encoded using _encoding_ E. Fail if X is not base64 encoded with encoding E
-- **Cost**: 25
-- LogicSigVersion >= 6
-
-Decodes X using the base64 encoding E. Specify the encoding with an immediate arg either as URL and Filename Safe (`URLEncoding`) or Standard (`StdEncoding`). See <a href="https://rfc-editor.org/rfc/rfc4648.html#section-4">RFC 4648</a> (sections 4 and 5). It is assumed that the encoding ends with the exact number of `=` padding characters as required by the RFC. When padding occurs, any unused pad bits in the encoding must be set to zero or the decoding will fail. The special cases of `\n` and `\r` are allowed but completely ignored. An error will result when attempting to decode a string with a character that is not in the encoding alphabet or not one of `=`, `\r`, or `\n`.
-
 ## balance
 
 - Opcode: 0x60

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -482,10 +482,6 @@ var globalFieldDocs = map[string]string{
 	"CallerApplicationAddress":  "The application address of the application that called this application. ZeroAddress if this application is at the top-level.",
 }
 
-type extractor interface {
-	getExtraFor(string) string
-}
-
 func addExtra(original string, extra string) string {
 	if len(original) == 0 {
 		return extra
@@ -498,15 +494,6 @@ func addExtra(original string, extra string) string {
 		sep = " "
 	}
 	return original + sep + extra
-}
-
-func fieldsDocWithExtra(source map[string]string, ex extractor) map[string]string {
-	result := make(map[string]string, len(source))
-	for name, doc := range source {
-		extra := ex.getExtraFor(name)
-		result[name] = addExtra(doc, extra)
-	}
-	return result
 }
 
 // AssetHoldingFieldDocs are notes on fields available in `asset_holding_get`

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -17,8 +17,6 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -557,49 +555,24 @@ var base64EncodingSpecByName base64EncodingSpecMap
 
 type base64EncodingSpecMap map[string]base64EncodingSpec
 
+func (fs *base64EncodingSpec) Type() StackType {
+	return fs.ftype
+}
+
+func (fs *base64EncodingSpec) OpVersion() uint64 {
+	return 6
+}
+
+func (fs *base64EncodingSpec) Version() uint64 {
+	return fs.version
+}
+
+func (fs *base64EncodingSpec) Note() string {
+	note := "" // no doc list?
+	return note
+}
 func (s base64EncodingSpecMap) getExtraFor(name string) (extra string) {
 	// Uses 6 here because base64_decode fields were introduced in 6
-	if s[name].version > 6 {
-		extra = fmt.Sprintf("Introduced v%d.", s[name].version)
-	}
-	return
-}
-
-// Base64Encoding is an enum for the `base64decode` opcode
-type Base64Encoding int
-
-const (
-	// URLEncoding represents the base64url encoding defined in https://www.rfc-editor.org/rfc/rfc4648.html
-	URLEncoding Base64Encoding = iota
-	// StdEncoding represents the standard encoding of the RFC
-	StdEncoding
-	invalidBase64Alphabet
-)
-
-// After running `go generate` these strings will be available:
-var base64EncodingNames [2]string = [...]string{URLEncoding.String(), StdEncoding.String()}
-
-type base64EncodingSpec struct {
-	field   Base64Encoding
-	ftype   StackType
-	version uint64
-}
-
-var base64EncodingSpecs = []base64EncodingSpec{
-	{URLEncoding, StackBytes, 6},
-	{StdEncoding, StackBytes, 6},
-}
-
-var base64EncodingSpecByField map[Base64Encoding]base64EncodingSpec
-var base64EncodingSpecByName base64EncodingSpecMap
-
-type base64EncodingSpecMap map[string]base64EncodingSpec
-
-func (s base64EncodingSpecMap) getExtraFor(name string) (extra string) {
-	// Uses 6 here because base64_decode fields were introduced in 6
-	if s[name].version > 6 {
-		extra = fmt.Sprintf("LogicSigVersion >= %d.", s[name].version)
-	}
 	return
 }
 


### PR DESCRIPTION
* Three new globals for to help contract-to-contract usability

* detritis

* Check error

* doc comments

* Impose limits on the entire "tree" of inner calls.

This also increases the realism of testing of multiple app calls in a
group by creating the EvalParams with the real constructor, thus
getting the pooling stuff tested here without playing games
manipulating the ep after construction.

* Move appID tracking into EvalContext, out of LedgerForLogic

This change increases the seperation between AVM execution and the
ledger being used to lookup resources.  Previously, the ledger kept
track of the appID being executed, to offer a narrower interface to
those resources. But now, with app-to-app calls, the appID being
executed must change, and the AVM needs to maintain the current appID.

* Stupid linter

* Fix unit tests error messages

* Allow access to resources created in the same transaction group

The method will be reworked, but the tests are correct and want to get
them visible to team.

* Access to apps created in group

Also adds some tests that are currently skipped for testing
- access to addresses of newly created apps
- use of gaid in inner transactions

Both require some work to implement the thing being tested.

* Remove tracked created mechanism in favor of examining applydata.

* Allow v6 AVM code to use in-group created asas, apps (& their accts)

One exception - apps can not mutate (put or del) keys from the app
accounts, because EvalDelta cannot encode such changes.

* lint docs

* typo

* The review dog needs obedience training.

* Use one EvalParams for logic evals, another for apps in dry run

We used to use one ep per transaction, shared between sig and and
app. But the new model of ep usage is to keep using one while
evaluating an entire group.

The app ep is now built logic.NewAppEvalParams which, hopefully, will
prevent some bugs when we change something in the EvalParams and don't
reflect it in what was a "raw" EvalParams construction in debugger and
dry run.

* Use logic.NewAppEvalParams to decrease copying and bugs in debugger

* Simplify use of NewEvalParams. No more nil return when no apps.

This way, NewEvalParams can be used for all creations of EvalParams,
whether they are intended for logicsig or app use, greatly simplifying
the way we make them for use by dry run or debugger (where they serve
double duty).

* Remove explicit PastSideEffects handling in tealdbg

* Always create EvalParams to evaluate a transaction group.

We used to have an optimization to avoid creating EvalParams unless
there was an app call in the transaction group.  But the interface to
allow transaction processing to communicate changes into the
EvalParams is complicated by that (we must only do it if there is
one!)

This also allows us to use the same construction function for eps
created for app and logic evaluation, simplifying dry-run and
debugger.

The optimization is less needed now anyway:
1) The ep is now shared for the whole group, so it's only one.
2) The ep is smaller now, as we only store nil pointers instead of
larger scratch space objects for non-app calls.

* Correct mistaken commit

* Spec improvments

* More spec improvments, including resource "availability"

* Recursively return inner transaction tree

* Lint

* No need for ConfirmedRound, so don't deref a nil pointer!

* license check

* Shut up, dawg.

* base64 merge cleanup

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
