### PR TITLE
Remove unused function:  typeEnumTableMarkdown

### DIFF
--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -33,7 +33,6 @@ func opGroupMarkdownTable(names []string, out io.Writer) {
 | - | -- |
 `)
 	opSpecs := logic.OpsByName[logic.LogicVersion]
-	// TODO: sort by logic.OpSpecs[].Opcode
 	for _, opname := range names {
 		spec, ok := opSpecs[opname]
 		if !ok {
@@ -47,15 +46,6 @@ func opGroupMarkdownTable(names []string, out io.Writer) {
 
 func markdownTableEscape(x string) string {
 	return strings.ReplaceAll(x, "|", "\\|")
-}
-
-func typeEnumTableMarkdown(out io.Writer) {
-	fmt.Fprintf(out, "| Index | \"Type\" string | Description |\n")
-	fmt.Fprintf(out, "| --- | --- | --- |\n")
-	for i, name := range logic.TxnTypeNames {
-		fmt.Fprintf(out, "| %d | %s | %s |\n", i, markdownTableEscape(name), logic.TypeNameDescriptions[name])
-	}
-	out.Write([]byte("\n"))
 }
 
 func integerConstantsTableMarkdown(out io.Writer) {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -837,10 +837,10 @@ func asmItxn(ops *OpStream, spec *OpSpec, args []string) error {
 		itxna := OpsByName[ops.Version]["itxna"]
 		return asmDefault(ops, &itxna, args)
 	}
-	return ops.errorf("%s expects 2 or 3 immediate arguments", spec.Name)
+	return ops.errorf("%s expects 1 or 2 immediate arguments", spec.Name)
 }
 
-// asmGitxn substitutes gitna's spec if the are 3 args
+// asmGitxn substitutes gitna's spec if there are 3 args
 func asmGitxn(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) == 2 {
 		return asmDefault(ops, spec, args)

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -566,7 +566,7 @@ func OpcodesByVersion(version uint64) []OpSpec {
 // direct opcode bytes
 var opsByOpcode [LogicVersion + 1][256]OpSpec
 
-// OpsByName map for each each version, mapping opcode name to OpSpec
+// OpsByName map for each version, mapping opcode name to OpSpec
 var OpsByName [LogicVersion + 1]map[string]OpSpec
 
 // Migration from TEAL v1 to TEAL v2.


### PR DESCRIPTION
## Summary

Makes minor changes observed while reviewing https://github.com/algorand/go-algorand/pull/3857:
* Remove unused function:  `typeEnumTableMarkdown`.
* Remove TODO present since 2019.  Presumably, it's safe to disregard the concern.
* Correct a few typos.

## Test Plan

`make install`
