### PR TITLE
Retain type tracking state during consecutive type tracking enablements

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2506,4 +2506,14 @@ done:
 #pragma typetrack true
  concat
 `, LogicVersion)
+
+	// Declaring type tracking on consecutively does _not_ reset type tracking state.
+	testProg(t, `
+ int 1
+ int 2
+#pragma typetrack true
+ concat
+#pragma typetrack true
+ concat
+`, LogicVersion, Expect{5, "concat arg 1 wanted type []byte..."})
 }


### PR DESCRIPTION
Retains type tracking state when encountering consecutive `typetrack true` statements.

Details:
* The PR presumes it's _correct_ to retain existing type tracking state when encountering `typetrack true` statements.  For illustration, the PR supplies a test case that fails without the source changes.
* Optionally adds a `reset` method to centralize state management.  If preferred, the change change be reverted.