### PR TITLE
Centralize OpStream initialization by introducing factory method

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1298,7 +1298,6 @@ func (ops *OpStream) assemble(text string) error {
 		return ops.errorf("Can not assemble version %d", ops.Version)
 	}
 	scanner := bufio.NewScanner(fin)
-	ops.sourceLine = 0
 	for scanner.Scan() {
 		ops.sourceLine++
 		line := scanner.Text()

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -638,7 +638,7 @@ func TestOpUint(t *testing.T) {
 
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			ops := OpStream{Version: v}
+			ops := NewOpStream(v)
 			ops.Uint(0xcafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
@@ -656,7 +656,7 @@ func TestOpUint64(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			t.Parallel()
-			ops := OpStream{Version: v}
+			ops := NewOpStream(v)
 			ops.Uint(0xcafebabecafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
@@ -672,7 +672,7 @@ func TestOpBytes(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			ops := OpStream{Version: v}
+			ops := NewOpStream(v)
 			ops.ByteLiteral([]byte("abcdef"))
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -482,7 +482,8 @@ func testMatch(t testing.TB, actual, expected string) bool {
 }
 
 func assemblyTrace(text string, ver uint64) string {
-	ops := OpStream{Version: ver, Trace: &strings.Builder{}}
+	ops := NewOpStream(ver)
+	ops.Trace = &strings.Builder{}
 	ops.assemble(text)
 	return ops.Trace.String()
 }
@@ -2301,7 +2302,7 @@ func TestBranchAssemblyTypeCheck(t *testing.T) {
 	btoi              // [n]
 `
 
-	ops := OpStream{Version: AssemblerMaxVersion}
+	ops := NewOpStream(AssemblerMaxVersion)
 	err := ops.assemble(text)
 	require.NoError(t, err)
 	require.Empty(t, ops.Warnings)
@@ -2316,7 +2317,7 @@ flip:                 // [x]
 	btoi              // [n]
 `
 
-	ops = OpStream{Version: AssemblerMaxVersion}
+	ops = NewOpStream(AssemblerMaxVersion)
 	err = ops.assemble(text)
 	require.NoError(t, err)
 	require.Empty(t, ops.Warnings)


### PR DESCRIPTION
Centralizes OpStream initialization by introducing `NewOpStream` factory method.

Stems from discussion in https://github.com/algorand/go-algorand/pull/3870#discussion_r849880989.