### PR TITLE
Refactor to reuse NewEvalParams

### DIFF
--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -157,44 +157,15 @@ func (ep *EvalParams) reset() {
 		ep.available.apps = nil
 		ep.available.asas = nil
 		// reinitialize boxes because evaluation can add box refs for app creates.
-		ep.available.boxes = ep.recalcBoxRefs()
+		available := NewEvalParams(ep.TxnGroup, ep.Proto, ep.Specials).available
+		if available != nil {
+			ep.available.boxes = available.boxes
+		}
 	}
 	ep.appAddrCache = make(map[basics.AppIndex]basics.Address)
 	if ep.Trace != nil {
 		ep.Trace = &strings.Builder{}
 	}
-}
-
-// reinitializeBoxRefs is nearly a copy of what happens in NewEvalParams, but is
-// in _test.go because it never needs to happen in normal operation.
-func (ep *EvalParams) recalcBoxRefs() map[basics.AppIndex][]string {
-	var allBoxes map[basics.AppIndex][]string
-	for _, tx := range ep.TxnGroup {
-		if tx.Txn.Type == protocol.ApplicationCallTx {
-			if allBoxes == nil && len(tx.Txn.Boxes) > 0 {
-				allBoxes = make(map[basics.AppIndex][]string)
-			}
-			for _, br := range tx.Txn.Boxes {
-				var app basics.AppIndex
-				if br.Index == 0 {
-					// 0 is the "current app". Ignore if this is a create, else use ApplicationID
-					if tx.Txn.ApplicationID == 0 {
-						// When the create actually happens, and we learn the appID, we'll make it _available_.
-						continue
-					}
-					app = tx.Txn.ApplicationID
-				} else {
-					// Bounds check will already have been done by
-					// WellFormed. For testing purposes, it's better to panic
-					// now than after returning a nil.
-					app = tx.Txn.ForeignApps[br.Index-1] // shift for the 0=this convention
-				}
-				appBoxes := allBoxes[app]
-				allBoxes[app] = append(appBoxes, br.Name)
-			}
-		}
-	}
-	return allBoxes
 }
 
 func TestTooManyArgs(t *testing.T) {


### PR DESCRIPTION
Optionally proposes an alternative approach that avoids code duplication with a test-only method.

It feels _a bit_ strange to call `NewEvalParams` in `EvalParams.reset` though it removes code duplication.  I understand the preference for avoiding a private method in source code.

Rationale:  The PR is less likely to get out-of-sync over time because only 1 method must be maintained.

Reference:  https://github.com/algorand/go-algorand/pull/4001/commits/8a2230fac92197a4a92c023b781636cfd7335c89