### PR TITLE
Fix small bug and other improvements

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1130,7 +1130,7 @@ func getImm(args []string, argIndex int) (int, bool) {
 		return 0, false
 	}
 	// We want to parse anything from -128 up to 255. So allow 9 bits.
-	// Normal assembly checkign willl catch signed as byte, vice versa
+	// Normal assembly checking will catch signed as byte, vice versa
 	n, err := strconv.ParseInt(args[argIndex], 0, 9)
 	if err != nil {
 		return 0, false

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2157,7 +2157,7 @@ func opRetSub(cx *EvalContext) error {
 				return fmt.Errorf("retsub executed with no return values on stack. proto declared %d", frame.returns)
 			default:
 				return fmt.Errorf("retsub executed with %d return values on stack. proto declared %d",
-					expect-len(cx.stack), frame.returns)
+					len(cx.stack)-frame.height, frame.returns)
 			}
 		}
 		argstart := frame.height - frame.args

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4411,7 +4411,7 @@ func TestBury(t *testing.T) {
 	// bury 0 panics
 	source := "int 3; int 2; int 7; bury 0; int 1; return"
 	testProg(t, source, 8, Expect{1, "bury 0 always fails"})
-	testPanics(t, notrack("int 3; int 2; int 7; bury 0; int 1; return"), 8)
+	testPanics(t, notrack("int 3; int 2; int 7; bury 0; int 1; return"), 8, "bury outside stack")
 
 	// bury 1 pops the ToS and replaces the thing "1 down", which becomes the new ToS
 	testAccepts(t, "int 3; int 2; int 7; bury 1; int 7; ==; assert; int 3; ==", 8)
@@ -4424,7 +4424,7 @@ func TestBury(t *testing.T) {
 `, 8)
 
 	// bury too deep
-	testPanics(t, notrack("int 3; int 2; int 7;	bury 3; int 1; return"), 8)
+	testPanics(t, notrack("int 3; int 2; int 7;	bury 3; int 1; return"), 8, "bury outside stack")
 }
 
 func TestCover(t *testing.T) {

--- a/data/transactions/logic/frames_test.go
+++ b/data/transactions/logic/frames_test.go
@@ -232,7 +232,7 @@ func TestForgetReturn(t *testing.T) {
         retsub
   main: callsub a
         !
-`, fpVersion)
+`, fpVersion, "retsub executed with no return values on stack")
 
 	testPanics(t, `
         b main
@@ -241,7 +241,7 @@ func TestForgetReturn(t *testing.T) {
         retsub
   main: callsub a
         !
-`, fpVersion)
+`, fpVersion, "retsub executed with 2 return values on stack")
 
 	// Extra is fine. They are "locals", and they are cleared
 	testAccepts(t, `
@@ -394,10 +394,6 @@ func TestFrameDigAtStart(t *testing.T) {
 	testPanics(t, `
         frame_dig 1
 `, fpVersion, "frame_dig with empty callstack")
-
-	testPanics(t, `
-        frame_dig -1
-`, fpVersion, "frame_dig with empty callstack")
 }
 
 func TestFrameAccessAboveStack(t *testing.T) {
@@ -504,5 +500,5 @@ double_both:
      retsub
 `
 	testProg(t, source, fpVersion)
-	testAccepts(t, notrack(source), fpVersion)
+	testAccepts(t, source, fpVersion)
 }


### PR DESCRIPTION
I discovered a bug in one of the `opRetSub` error messages, which would report the wrong number of values that the subroutine attempted to return.

I also included other miscellaneous improvements.