### PR TITLE
Fix box_put dirtyBytes calculation bug

### DIFF
--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -386,18 +386,16 @@ func TestWriteBudgetPut(t *testing.T) {
 
 	// Sample tx[0] has two box refs, so write budget is 2*100
 
-	// Creating a box with box_put
-	{
+	t.Run("Creating a box with box_put", func(t *testing.T) {
 		// Size == budget allows creation.
 		logic.TestApp(t, `byte "self"; int 200; bzero; box_put
                          byte "self"; box_del; assert; int 1`, ep)
 
 		// Size > budget does not allow creation.
 		logic.TestApp(t, `byte "self"; int 201; bzero; box_put; int 1`, ep, "write budget")
-	}
+	})
 
-	// Test simple use of one box, less than, equal, or over budget
-	{
+	t.Run("Test simple use of one box, less than, equal, or over budget", func(t *testing.T) {
 		logic.TestApp(t, `byte "self"; int 150; box_create`, ep)
 		logic.TestApp(t, `byte "self"; int 150; bzero; box_put; int 1`, ep)
 		logic.TestApp(t, `byte "self"; int 149; bzero; byte "x"; concat; box_put; int 1`, ep)
@@ -410,7 +408,7 @@ func TestWriteBudgetPut(t *testing.T) {
 		logic.TestApp(t, `byte "self"; int 150; bzero; box_put;
 	                  byte "other"; int 149; bzero; byte "x"; concat; box_put; int 1`, ep,
 			"write budget")
-	}
+	})
 }
 
 // TestBoxRepeatedCreate ensures that app is not charged write budget for
@@ -500,8 +498,7 @@ func TestConveniences(t *testing.T) {
 	logic.TestApp(t, `byte "self"; box_get; assert; byte 0xAADDEE; ==`, ep)
 	ledger.DelBoxes(888, "self")
 
-	// box_get and box_put panic if the box is too big
-	{
+	t.Run("box_get and box_put panic if the box is too big", func(t *testing.T) {
 		ep.Proto.MaxBoxSize = 5000
 		ep.Proto.BytesPerBoxReference = 5000 // avoid write budget error
 		logic.TestApp(t, `byte "self"; int 4098; box_create; assert; // bigger than maxStringSize
@@ -511,7 +508,7 @@ func TestConveniences(t *testing.T) {
 
 		ep.Proto.MaxBoxSize = 4000
 		logic.TestApp(t, `byte "self"; int 4001; bzero; box_put; int 1`, ep, "box size too large")
-	}
+	})
 }
 
 func TestBoxTotals(t *testing.T) {

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -74,23 +74,20 @@ func TestBoxNewBad(t *testing.T) {
 
 	logic.TestApp(t, `byte "unknown"; int 1000; box_create`, ep, "invalid Box reference")
 
-	// Confirm name too long creation fails.
-	{
+	t.Run("Confirm name too long creation fails", func(t *testing.T) {
 		long := strings.Repeat("x", 65)
 		txn.Boxes = []transactions.BoxRef{{Name: []byte(long)}}
 		logic.TestApp(t, fmt.Sprintf(`byte "%s"; int 8; box_create`, long), ep, "name too long")
 		logic.TestApp(t, fmt.Sprintf(`byte "%s"; int 8; bzero; box_put`, long), ep, "name too long")
-	}
+	})
 
-	// Confirm empty name creation fails.
-	{
+	t.Run("Confirm empty name creation fails", func(t *testing.T) {
 		expectedProblem := "zero length"
 		logic.TestApp(t, `byte ""; int 100; box_create`, ep, expectedProblem)
 
 		txn.Boxes = []transactions.BoxRef{{Name: []byte("")}} // needed for box_put, not box_create because zero check comes first anyway
 		logic.TestApp(t, `byte ""; int 100; bzero; box_put`, ep, expectedProblem)
-	}
-
+	})
 }
 
 func TestBoxReadWrite(t *testing.T) {


### PR DESCRIPTION
Adds tests to generally improve coverage and fixes a (perceived) bug in `dirtyBytes` calculation.

`box_put` box creation Incorrectly supplies `len(contents)` to `createCheck`.  It's _incorrect_ because the expression evaluates to 0.  I think the desired behavior is to replace with `value`.

Additionally and if we agree it's a bug - I think `availableBox` may benefit from a refactoring to make such an error less likely.  I ran out of time in this iteration to deeply consider refactorings and at least want to present the problem with _a_ solution for consideration.