### PR TITLE
Extend box tests

### DIFF
--- a/ledger/boxtxn_test.go
+++ b/ledger/boxtxn_test.go
@@ -444,9 +444,9 @@ func TestBoxIOBudgets(t *testing.T) {
 		create := call.Args("create", "x", "\x10\x00")
 
 		// Slight detour - Prove insufficient funding fails creation.
-		fundApp.Amount -= 1
+		fundApp.Amount--
 		dl.txgroup("below min", &fundApp, create)
-		fundApp.Amount += 1
+		fundApp.Amount++
 
 		// Confirm desired creation happens.
 		dl.txgroup("", &fundApp, create)

--- a/ledger/boxtxn_test.go
+++ b/ledger/boxtxn_test.go
@@ -18,6 +18,7 @@ package ledger
 
 import (
 	"bytes"
+	"github.com/algorand/go-algorand/config"
 	"testing"
 	"time"
 
@@ -125,6 +126,10 @@ var passThruSource = main(`
 
 const boxVersion = 35
 
+func boxFee(p config.ConsensusParams, nameAndValueSize uint64) uint64 {
+	return p.BoxFlatMinBalance + p.BoxByteMinBalance*(nameAndValueSize)
+}
+
 // TestBoxCreate tests MBR changes around allocation, deallocation
 func TestBoxCreate(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -136,9 +141,10 @@ func TestBoxCreate(t *testing.T) {
 		defer dl.Close()
 
 		// increment for a size 24 box with 4 letter name
-		const mbr = 2500 + 28*400
+		proto := config.Consensus[cv]
+		mbr := boxFee(proto, 28)
 
-		appIndex := dl.fundedApp(addrs[0], 100_000+3*mbr, boxAppSource)
+		appIndex := dl.fundedApp(addrs[0], proto.MinBalance+3*mbr, boxAppSource)
 
 		call := txntest.Txn{
 			Type:          "appl",
@@ -195,9 +201,10 @@ func TestBoxRecreate(t *testing.T) {
 		defer dl.Close()
 
 		// increment for a size 4 box with 4 letter name
-		const mbr = 2500 + 8*400
+		proto := config.Consensus[cv]
+		mbr := boxFee(proto, 8)
 
-		appIndex := dl.fundedApp(addrs[0], 100_000+mbr, boxAppSource)
+		appIndex := dl.fundedApp(addrs[0], proto.MinBalance+mbr, boxAppSource)
 
 		call := txntest.Txn{
 			Type:          "appl",
@@ -263,11 +270,13 @@ func TestBoxCreateAvailability(t *testing.T) {
 		// the app address that we know the app will get. So this is a nice
 		// test, but unrealistic way to actual create a box.
 		psychic := basics.AppIndex(2)
+
+		proto := config.Consensus[cv]
 		dl.txn(&txntest.Txn{
 			Type:     "pay",
 			Sender:   addrs[0],
 			Receiver: psychic.Address(),
-			Amount:   100_000 + 2500 + 15*400,
+			Amount:   proto.MinBalance + boxFee(proto, 15),
 		})
 		dl.txn(&accessInCreate)
 
@@ -403,7 +412,7 @@ func TestBoxIOBudgets(t *testing.T) {
 		dl := NewDoubleLedger(t, genBalances, cv)
 		defer dl.Close()
 
-		appIndex := dl.fundedApp(addrs[0], 1_000_000, boxAppSource)
+		appIndex := dl.fundedApp(addrs[0], 0, boxAppSource)
 		call := txntest.Txn{
 			Type:          "appl",
 			Sender:        addrs[0],
@@ -424,14 +433,23 @@ func TestBoxIOBudgets(t *testing.T) {
 		dl.txn(call.Args("create", "x", "\x10\x01"), // 4097
 			"write budget (4096) exceeded")
 
-		var needed uint64 = 100_000 + 2500 + 400*(4096+1) // remember key len!
-		dl.txn(&txntest.Txn{
+		// Create 4,096 byte box
+		proto := config.Consensus[cv]
+		fundApp := txntest.Txn{
 			Type:     "pay",
 			Sender:   addrs[0],
 			Receiver: appIndex.Address(),
-			Amount:   needed - 1_000_000,
-		})
-		dl.txn(call.Args("create", "x", "\x10\x00"))
+			Amount:   proto.MinBalance + boxFee(proto, 4096+1), // remember key len!
+		}
+		create := call.Args("create", "x", "\x10\x00")
+
+		// Slight detour - Prove insufficient funding fails creation.
+		fundApp.Amount -= 1
+		dl.txgroup("below min", &fundApp, create)
+		fundApp.Amount += 1
+
+		// Confirm desired creation happens.
+		dl.txgroup("", &fundApp, create)
 
 		// Now that we've created a 4,096 byte box, test READ budget
 		// It works at the start, because call still has 4 brs.


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4622 with optional test modifications I made during my review.  There's _no_ correctness changes here.

The PR makes these kinds of modifications:
* Add at least 1 test case covering empty boxes in `TestBoxNewDel`.
* Modify `TestConsensusRange`-based tests to use consensus parameters for algo amounts (min balance and box fees).  The intent is to make the tests compatible with future consensus versions that _may_ change these values.
* Add an assertion confirming MBR arithmetic (see `// Slight detour - Prove insufficient funding fails creation.`).  I realize at least one other test makes a similar assertion though I felt it's _reasonable_ to add the check.

Feel welcomed to take some, none or all changes.